### PR TITLE
Fix duplicate UE4SS loader deployment

### DIFF
--- a/scripts/install-mods.sh
+++ b/scripts/install-mods.sh
@@ -372,11 +372,11 @@ deploy_mod_auto_discover() {
         chown steam:steam "${bin_dir}/dwmapi.dll" 2>/dev/null || true
         deployed_ue4ss_files+=("dwmapi.dll")
     elif [[ -f "${dest_dir}/UE4SS.dll" ]]; then
-        ei "  Found UE4SS.dll. Deploying and copying to dwmapi.dll..."
+        ei "  Found UE4SS.dll. Deploying as dwmapi.dll..."
         cp -f "${dest_dir}/UE4SS.dll" "${bin_dir}/dwmapi.dll"
-        cp -f "${dest_dir}/UE4SS.dll" "${bin_dir}/UE4SS.dll"
-        chown steam:steam "${bin_dir}/dwmapi.dll" "${bin_dir}/UE4SS.dll" 2>/dev/null || true
-        deployed_ue4ss_files+=("dwmapi.dll" "UE4SS.dll")
+        rm -f "${bin_dir}/UE4SS.dll"
+        chown steam:steam "${bin_dir}/dwmapi.dll" 2>/dev/null || true
+        deployed_ue4ss_files+=("dwmapi.dll")
     fi
 
     # Check for other dlls or settings
@@ -563,9 +563,9 @@ deploy_mod_via_rules() {
                             deployed_ue4ss_files+=("dwmapi.dll")
                         elif [[ -f "${target_path}/UE4SS.dll" ]]; then
                             cp -f "${target_path}/UE4SS.dll" "${bin_dir}/dwmapi.dll"
-                            cp -f "${target_path}/UE4SS.dll" "${bin_dir}/UE4SS.dll"
-                            chown steam:steam "${bin_dir}/dwmapi.dll" "${bin_dir}/UE4SS.dll" 2>/dev/null || true
-                            deployed_ue4ss_files+=("dwmapi.dll" "UE4SS.dll")
+                            rm -f "${bin_dir}/UE4SS.dll"
+                            chown steam:steam "${bin_dir}/dwmapi.dll" 2>/dev/null || true
+                            deployed_ue4ss_files+=("dwmapi.dll")
                         fi
                         for file in "UE4SS-settings.ini" "Vindsent.dll" "MemberVariableLayout.ini"; do
                             if [[ -f "${target_path}/${file}" ]]; then


### PR DESCRIPTION
﻿## What changed
- when a UE4SS package provides `UE4SS.dll`, deploy it as the Wine proxy loader `dwmapi.dll` only
- remove a previously deployed root `UE4SS.dll` to prevent upgrade leftovers from continuing to load
- track only `dwmapi.dll` in Workshop deployment state
- apply the same behavior to auto-discovered packages and `InstallRule`-based UE4SS packages

## Root cause
The installer copied the same UE4SS binary to both `Win64/dwmapi.dll` and `Win64/UE4SS.dll`. Under Wine, both modules were loaded and UE4SS initialized its mod system twice. This caused `AdminCommands` to register every command and native hook twice and created two UE4SS event loops.

## Impact
UE4SS now initializes once while retaining the required `dwmapi.dll` proxy loader. Mods and hooks are no longer duplicated.

## Live validation
On a Palworld Wine dedicated server using Workshop UE4SS Experimental:

- before removing the duplicate loader: 2 AdminCommands starts, 2 successful loads, and 2 event loops
- after a pre-start hook moved `Win64/UE4SS.dll` aside while retaining the identical `dwmapi.dll`: 1 AdminCommands start, 1 successful load, and 1 event loop
- DynamicBaseCount also changed from duplicate initialization to one initialization

## Checks
- `bash -n scripts/install-mods.sh`
- `git diff --check`
- targeted assertions verify both UE4SS deployment paths copy to `dwmapi.dll`, remove the root duplicate, and never copy to root `UE4SS.dll`
- searched the target and parent repositories for an overlapping PR before publishing
