### PR TITLE
detect_ue4ss_layout() still misclassifies a package as "root" when it also has a nested ue4ss/ folder (gap in #51)

### DIFF
--- a/scripts/install-mods.sh
+++ b/scripts/install-mods.sh
@@ -184,12 +184,17 @@ else
     fi
 fi
 
-# Report whether a package installs UE4SS at the Win64 root or in Win64/ue4ss.
-# Root-level proxy/framework DLLs take precedence over a bundled ue4ss folder.
+# Report whether a package installs UE4SS at the Win64 root or nested under
+# Win64/ue4ss. A nested ue4ss/ folder always wins over a root-level
+# dwmapi.dll/UE4SS.dll in the same candidate: modern packages ship a thin root
+# dwmapi.dll PROXY that forwards into a nested ue4ss/UE4SS.dll, and it's that
+# nested DLL - not the proxy - that actually runs and scans its own Mods
+# folder. Echoes "root", "nested", or nothing if the package has neither (e.g.
+# a plain Lua-only mod with no UE4SS framework files at all).
 detect_ue4ss_layout() {
     local package_dir="$1"
     local candidate
-    local nested_found=false
+    local layout=""
     local candidates=("$package_dir")
     local info_json="${package_dir}/Info.json"
 
@@ -206,18 +211,18 @@ detect_ue4ss_layout() {
     fi
 
     for candidate in "${candidates[@]}"; do
-        if [[ -f "${candidate}/UE4SS.dll" || -f "${candidate}/dwmapi.dll" ]]; then
-            echo "root"
-            return
-        fi
         if [[ -d "${candidate}/ue4ss" ]]; then
-            nested_found=true
+            # Nested is authoritative the moment we see it - no candidate
+            # after this one could change the answer.
+            echo "nested"
+            return
+        elif [[ -f "${candidate}/UE4SS.dll" || -f "${candidate}/dwmapi.dll" ]]; then
+            # Provisional only: a later candidate may still turn out nested.
+            layout="root"
         fi
     done
 
-    if [[ "$nested_found" == "true" ]]; then
-        echo "nested"
-    fi
+    echo "$layout"
 }
 
 # Purge legacy UE4SS files/directories if experimental UE4SS is activated to prevent conflicts


### PR DESCRIPTION
`detect_ue4ss_layout()` was introduced in #51 to resolve the UE4SS Mods
destination from the actual package being installed, replacing an older
heuristic that just checked whether `Win64/ue4ss` already existed on disk
(which could misfire on stale directories). #52 landed shortly after in the
same file, but touches a different function entirely (dedup of the deployed
loader file) - it doesn't change `detect_ue4ss_layout()` or `mods_base_dir`
resolution, and this PR doesn't overlap with it.

This PR is a narrow follow-up to #51: one specific package shape still gets
misclassified, for a reason that's easy to miss - the packages that trigger 
it look, at a glance, exactly like the "root" case #51's DLL check
was designed to catch.

## Problem

With `INSTALL_UE4SS_EXPERIMENTAL=true`, UE4SS itself loads correctly and
generates `UE4SS.log`, and the framework's own bundled default mods
(BPModLoaderMod, ConsoleEnablerMod, etc.) load fine. But user Lua mods placed
under `Mods/NativeMods/` (and Workshop Lua mods) never appear in `UE4SS.log`
and have no effect, even though the deploy log shows them being "deployed"
without error.

## Root cause

The downloaded Okaetsu experimental UE4SS package (default
`UE4SS_EXPERIMENTAL_URL`) is packaged as:

```
ue4ss-experimental/
|-- dwmapi.dll        <- thin proxy stub at the package root
`-- ue4ss/
    |-- UE4SS.dll     <- the real loader
    |-- UE4SS-settings.ini
    `-- Mods/         <- the folder UE4SS actually scans
```

`detect_ue4ss_layout()` checks each candidate for a root-level
`dwmapi.dll`/`UE4SS.dll` and returns `"root"` immediately on a match, before
ever checking that same candidate for a nested `ue4ss/` folder:

```bash
for candidate in "${candidates[@]}"; do
    if [[ -f "${candidate}/UE4SS.dll" || -f "${candidate}/dwmapi.dll" ]]; then
        echo "root"; return
    fi
    if [[ -d "${candidate}/ue4ss" ]]; then
        nested_found=true
    fi
done
```

Because this package has both, it's classified `"root"` on the strength of
the proxy `dwmapi.dll` alone - the nested `ue4ss/` folder holding the *actual*
loader is never checked. `.workshop-mods-state.json` confirms this on a live
install:

```json
{ "ue4ss_mods_layout": "root", "deployed_lua_mods": ["MaxStackCount", "InfiniteWeightInCamp"], "deployed_ue4ss_files": ["ue4ss", "dwmapi.dll"] }
```

`mods_base_dir` then resolves to `Win64/Mods`, and every Lua mod is deployed
there. But the deployed runtime is nested - `Win64/dwmapi.dll` is the proxy,
which loads `Win64/ue4ss/UE4SS.dll`, and *that* DLL is what actually runs.
`UE4SS.log` confirms it scans exactly one directory:

```
Loading mods from: Z:\palworld\Pal\Binaries\Win64\ue4ss\Mods
mods directories:
[0] Z:\palworld\Pal\Binaries\Win64\ue4ss\Mods
```

`UE4SS-settings.ini` has `ModsFolderPath =` empty, so there's no override
redirecting it back to `Win64/Mods`. Result: every Lua mod lands in a
directory nothing reads.

This is reproducible from the deploy code alone (independent of any specific
mod): `deploy_mod_via_rules()`'s `Lua` branch (for Workshop mods with a proper
`Info.json`/`InstallRule`) also targets `${mods_base_dir}/${pkg_name}`, so a
correctly-authored `Info.json` doesn't route around the problem either - both
mod-deployment paths share the same misresolved `mods_base_dir`.

## Proof / reproduction

Confirmed on a live deployment (image `:latest`, commit `e111fbf`):

1. Placed two real UE4SS Lua mods (Max Stack Count, Infinite Weight In Camp -
   both Steam Workshop mods) under `Mods/NativeMods/<name>/Scripts/`, per the
   README's "Manual/Native Mod Installation (Automated)" instructions.
2. Deploy log shows them being processed (`Deploying Native mod
   MaxStackCount...`) with no errors.
3. Confirmed on disk they land in `Win64/Mods/MaxStackCount/` and
   `Win64/Mods/InfiniteWeightInCamp/`.
4. Confirmed via `UE4SS.log` that the running UE4SS only scans
   `Win64/ue4ss/Mods` - the two mods never appear anywhere in the log.
5. **Positive control:** manually copied the same two mod folders (unmodified)
   into `Win64/ue4ss/Mods/`, added an `enabled.txt` to each. On next boot they
   load correctly with no errors:
   ```
   Mod 'InfiniteWeightInCamp' has enabled.txt, starting mod.
   [Lua] [InfiniteWeightInCamp] loaded build 3.0.2 (boost=1000000, watch=100ms, refresh=F6)
   Mod 'MaxStackCount' has enabled.txt, starting mod.
   [Lua] Max Stack Count version 1.4 intended for UE4SS experimental-palworld (260710) loaded for game version 1.0
   ```
   This confirms the mods themselves are valid and the *only* problem is
   directory placement.

## Fix

Check for the nested `ue4ss/` folder first, within each candidate. Nested is
authoritative the moment it's seen (no later candidate could change the
answer, so it still short-circuits with an early return). A root-level DLL
only sets a provisional result that a later candidate's nested folder can
still override. The function now always reaches an explicit `echo "$layout"`,
including the empty-string case for packages with neither a root DLL nor a
nested folder (e.g. plain Lua-only mods).

```diff
-# Report whether a package installs UE4SS at the Win64 root or in Win64/ue4ss.
-# Root-level proxy/framework DLLs take precedence over a bundled ue4ss folder.
+# Report whether a package installs UE4SS at the Win64 root or nested under
+# Win64/ue4ss. A nested ue4ss/ folder always wins over a root-level
+# dwmapi.dll/UE4SS.dll in the same candidate: modern packages ship a thin root
+# dwmapi.dll PROXY that forwards into a nested ue4ss/UE4SS.dll, and it's that
+# nested DLL - not the proxy - that actually runs and scans its own Mods
+# folder. Echoes "root", "nested", or nothing if the package has neither (e.g.
+# a plain Lua-only mod with no UE4SS framework files at all).
 detect_ue4ss_layout() {
     local package_dir="$1"
     local candidate
-    local nested_found=false
+    local layout=""
     local candidates=("$package_dir")
     local info_json="${package_dir}/Info.json"
 
     if [[ -f "$info_json" ]]; then
         while IFS= read -r target; do
             local clean_target="${target#./}"
             clean_target="${clean_target#/}"
             if [[ "$clean_target" == "." || -z "$clean_target" ]]; then
                 candidates+=("$package_dir")
             else
                 candidates+=("${package_dir}/${clean_target}")
             fi
         done < <(jq -r '.InstallRule[]? | select(.Type == "UE4SS") | .Targets[]? // empty' "$info_json" 2>/dev/null)
     fi
 
     for candidate in "${candidates[@]}"; do
-        if [[ -f "${candidate}/UE4SS.dll" || -f "${candidate}/dwmapi.dll" ]]; then
-            echo "root"
-            return
-        fi
         if [[ -d "${candidate}/ue4ss" ]]; then
-            nested_found=true
+            # Nested is authoritative the moment we see it - no candidate
+            # after this one could change the answer.
+            echo "nested"
+            return
+        elif [[ -f "${candidate}/UE4SS.dll" || -f "${candidate}/dwmapi.dll" ]]; then
+            # Provisional only: a later candidate may still turn out nested.
+            layout="root"
         fi
     done
 
-    if [[ "$nested_found" == "true" ]]; then
-        echo "nested"
-    fi
+    echo "$layout"
 }
```

Minimal, contained to this one function. Doesn't touch the
`Info.json`/`InstallRule` candidate-resolution logic above it (also from
#51), the per-run package-discovery/state-fallback logic below it (also #51),
or `deploy_mod()`/`deploy_mod_auto_discover()`/`deploy_mod_via_rules()`.
Doesn't touch anything from #52 (different function, no shared code).

## Testing

**1. Standalone harness.** Extracted `detect_ue4ss_layout()` (before and
after) into a script and ran both against synthetic directory structures,
including extracting the function directly from the real patched file (not a
hand-transcription) as a final check against transcription error:

| Case | Before | After | Expected |
|---|---|---|---|
| Experimental package (root proxy dwmapi.dll + nested ue4ss/UE4SS.dll) - the actual bug | `root` (wrong) | `nested` | `nested` |
| Genuine root-only package (dwmapi.dll, no nested ue4ss/) | `root` | `root` | `root` (no regression) |
| Genuine nested-only package (ue4ss/ present, no root DLL) | `nested` | `nested` | `nested` (no regression) |
| Plain Lua mod package (Scripts/ only, no DLLs) | *(empty)* | *(empty)* | *(empty)*, unchanged |
| Info.json/InstallRule Target -> nested proxy+payload subdir | `root` (wrong) | `nested` | `nested` |
| Info.json/InstallRule Target -> root-only subdir | `root` | `root` | `root` (no regression) |
| Order independence: root candidate scanned *before* a nested candidate (multi-target Info.json) | `root` (wrong - first match wins) | `nested` | `nested` (nested wins regardless of scan order) |

All 7 cases pass after the fix, 0 regressions. `bash -n` passes on the patched
file.

**2. Live validation, no image build (ConfigMap subPath override).** Mounted
the patched `install-mods.sh` over the file inside a running container of the
current `:latest` image (`e111fbf`), replacing nothing else. Result:
`.workshop-mods-state.json` changed from `"ue4ss_mods_layout": "root"` to
`"nested"`; two real Steam Workshop UE4SS Lua mods (Max Stack Count, Infinite
Weight In Camp) deployed straight to `Win64/ue4ss/Mods` through the plain,
documented `Mods/NativeMods/<name>/Scripts/` layout - no wrapper folders, no
manual `enabled.txt`; `mods.txt` was auto-updated to enable both
(`InfiniteWeightInCamp : 1`, `MaxStackCount : 1`); `UE4SS.log` shows both
starting and running with no errors; the dead `Win64/Mods` directory no
longer even exists.

**3. Live validation, real built image.** Built and pushed an actual image
from this branch via GHCR Actions, redeployed with zero overrides of any kind
(this fix is the only diff from upstream `e111fbf` in the image), and
reproduced the exact same result end to end: `"ue4ss_mods_layout": "nested"`,
both mods auto-registered in `mods.txt`, both loading cleanly in
`UE4SS.log`.

**4. Manual in-game confirmation.** Logged into the running server and
confirmed Infinite Weight In Camp's actual gameplay effect (no weight limit
while in a base camp) working as intended.
