### PR TITLE
fix: give the game process a real pty to fix garbled Wine console output

### DIFF
--- a/includes/server.sh
+++ b/includes/server.sh
@@ -93,7 +93,7 @@ function start_server() {
     es ">>> Starting the gameserver"
     # Real pty (via script) so Wine's WriteConsoleW transcodes instead of emitting raw UTF-16LE
     local wine_cmd
-    wine_cmd=$(printf '%q ' "${WINE_BIN}" "${GAME_BIN}" "${START_OPTIONS[@]}")
+    wine_cmd=$(printf 'exec %q ' "${WINE_BIN}" "${GAME_BIN}" "${START_OPTIONS[@]}")
     script -qec "${wine_cmd}" /dev/null
 }
 

--- a/includes/server.sh
+++ b/includes/server.sh
@@ -93,7 +93,7 @@ function start_server() {
     es ">>> Starting the gameserver"
     # Real pty (via script) so Wine's WriteConsoleW transcodes instead of emitting raw UTF-16LE
     local wine_cmd
-    wine_cmd=$(printf 'exec %q ' "${WINE_BIN}" "${GAME_BIN}" "${START_OPTIONS[@]}")
+    wine_cmd="exec $(printf '%q ' "${WINE_BIN}" "${GAME_BIN}" "${START_OPTIONS[@]}")"
     script -qec "${wine_cmd}" /dev/null
 }
 

--- a/includes/server.sh
+++ b/includes/server.sh
@@ -91,7 +91,10 @@ function start_server() {
     check_and_run_custom_script
 
     es ">>> Starting the gameserver"
-    "${WINE_BIN}" "${GAME_BIN}" "${START_OPTIONS[@]}"
+    # Real pty (via script) so Wine's WriteConsoleW transcodes instead of emitting raw UTF-16LE
+    local wine_cmd
+    wine_cmd=$(printf '%q ' "${WINE_BIN}" "${GAME_BIN}" "${START_OPTIONS[@]}")
+    script -qec "${wine_cmd}" /dev/null
 }
 
 function stop_server() {


### PR DESCRIPTION
Some log lines written directly by `PalServer-Win64-Shipping-Cmd.exe` (not the wrapper's own bash output) come out as unreadable scrambled Unicode in `docker logs`.

**Root cause:** Wine's `WriteConsoleW` writes raw UTF-16LE straight through when stdout is a plain pipe, instead of transcoding to single-byte text the way it does with a real console. Docker gives containers a pipe, not a tty, so this fires on every boot. I confirmed this by decoding a garbled line byte-for-byte back to its original ASCII text — it turned out to be things like `Game version is v1.0.2.101103` and the save-backup startup warning, just scrambled.

**Fix:** wrap the wine invocation in `script -qec ... /dev/null` to give the process a real pty, which restores Wine's normal console-transcoding codepath. `script` ships in `bsdutils`, present on Debian by default, so no new dependency.

**Testing done against a live server:**
- Verified the fix produces clean, readable output across two restarts, using a known-reproducible warning message (`bIsUseBackupSaveData=False`) as a repeatable test case.
- Verified no regression in shutdown paths: graceful in-game shutdown via the REST API, and a full `docker stop`/`docker start` cycle (SIGTERM -> `stop_server()`'s staged shutdown). Both completed cleanly, exit code 143, no orphaned processes, world save confirmed before shutdown.
- Verified log completeness under load: 150 sequential and 100 concurrent REST requests, all producing correctly formed, uncorrupted log lines. A real player happened to connect mid-test and had no issues.
- Checked process tree before/after: the extra `script`/`sh -c` layer doesn't leave anything orphaned when the game process exits and `servermanager.sh`'s loop restarts it.

Happy to adjust the approach if you'd prefer a different mechanism (e.g. `socat`) or want the comment reworded.

---
*This fix was written with the assistance of Claude Code. All tests described above were verified by me directly, including connecting to the server as a real player and confirming gameplay still works normally.*