### PR TITLE
fix: native mod loading and update detection

### DIFF
--- a/scripts/install-mods.sh
+++ b/scripts/install-mods.sh
@@ -164,7 +164,33 @@ if [[ "$server_running" == "true" ]]; then
                 break
             fi
         done
-        
+
+        # Check native mods for version changes, measured against the staging
+        # source dir rather than the deployed copy (which gets recreated on
+        # every restart regardless of content, so its mtime isn't stable)
+        native_mods_dir_check="${GAME_ROOT}/Mods/NativeMods"
+        if [[ -d "$native_mods_dir_check" ]]; then
+            for mod_path in "$native_mods_dir_check"/*; do
+                [[ -d "$mod_path" ]] || continue
+                mod_name=$(basename "$mod_path")
+
+                old_ver=$(echo "$old_versions" | jq -r --arg id "native_${mod_name}" '.[$id] // empty')
+                if [[ -f "${mod_path}/Info.json" ]]; then
+                    new_ver=$(jq -r '.Version // "unknown"' "${mod_path}/Info.json" 2>/dev/null || echo "unknown")
+                else
+                    new_ver="exists"
+                fi
+                new_mtime=$(stat -c %Y "$mod_path" 2>/dev/null || echo "0")
+                new_composite_ver="${new_ver}_${new_mtime}"
+
+                if [[ -z "$old_ver" || "$old_ver" != "$new_composite_ver" ]]; then
+                    dbgi "Native mod $mod_name version changed: old='$old_ver', new='$new_composite_ver'"
+                    live_update_detected=true
+                    break
+                fi
+            done
+        fi
+
         # Check if any configured ID was removed
         old_ids=$(echo "$old_versions" | jq -r 'keys[]?' 2>/dev/null)
         while IFS= read -r old_id; do
@@ -1068,13 +1094,13 @@ for id in "${unique_ids[@]}"; do
 done
 
 for mod_name in "${native_mod_names[@]}"; do
-    info_json="${mods_base_dir}/${mod_name}/Info.json"
+    info_json="${native_mods_dir}/${mod_name}/Info.json"
     if [[ -f "$info_json" ]]; then
         version=$(jq -r '.Version // "unknown"' "$info_json" 2>/dev/null || echo "unknown")
     else
         version="exists"
     fi
-    mtime=$(stat -c %Y "${mods_base_dir}/${mod_name}" 2>/dev/null || echo "0")
+    mtime=$(stat -c %Y "${native_mods_dir}/${mod_name}" 2>/dev/null || echo "0")
     composite_ver="${version}_${mtime}"
     versions_json=$(echo "$versions_json" | jq --arg id "native_${mod_name}" --arg ver "$composite_ver" '. + {($id): $ver}')
 done

--- a/scripts/install-mods.sh
+++ b/scripts/install-mods.sh
@@ -167,7 +167,8 @@ if [[ "$server_running" == "true" ]]; then
         
         # Check if any configured ID was removed
         old_ids=$(echo "$old_versions" | jq -r 'keys[]?' 2>/dev/null)
-        for old_id in $old_ids; do
+        while IFS= read -r old_id; do
+            [[ -z "$old_id" ]] && continue
             # native_* keys aren't Workshop IDs, skip them
             if [[ "$old_id" == native_* ]]; then
                 continue
@@ -184,7 +185,7 @@ if [[ "$server_running" == "true" ]]; then
                 live_update_detected=true
                 break
             fi
-        done
+        done <<< "$old_ids"
     fi
 
     if [[ "$live_update_detected" == "true" ]]; then

--- a/scripts/install-mods.sh
+++ b/scripts/install-mods.sh
@@ -168,6 +168,10 @@ if [[ "$server_running" == "true" ]]; then
         # Check if any configured ID was removed
         old_ids=$(echo "$old_versions" | jq -r 'keys[]?' 2>/dev/null)
         for old_id in $old_ids; do
+            # native_* keys aren't Workshop IDs, skip them
+            if [[ "$old_id" == native_* ]]; then
+                continue
+            fi
             is_still_configured=false
             for id in "${unique_ids[@]}"; do
                 if [[ "$id" == "$old_id" ]]; then

--- a/scripts/install-mods.sh
+++ b/scripts/install-mods.sh
@@ -641,15 +641,19 @@ deploy_mod_auto_discover() {
             deployed_palschema_mods+=("$pkg_name")
         fi
     elif [[ -d "${dest_dir}/mods" ]]; then
-        ei "  Found PalSchema mods directory (lowercase mods). Deploying..."
-        mkdir -p "${mods_base_dir}/PalSchema/mods"
-        cp -r "${dest_dir}/mods"/. "${mods_base_dir}/PalSchema/mods"/
-        chown -R steam:steam "${mods_base_dir}/PalSchema/mods" 2>/dev/null || true
-        for d in "${dest_dir}/mods"/*; do
-            if [[ -d "$d" ]]; then
-                deployed_palschema_mods+=($(basename "$d"))
-            fi
-        done
+        if [[ "${dest_dir}/mods" -ef "${mods_base_dir}/PalSchema/mods" ]]; then
+            dbgi "  PalSchema mods directory is already in place, skipping."
+        else
+            ei "  Found PalSchema mods directory (lowercase mods). Deploying..."
+            mkdir -p "${mods_base_dir}/PalSchema/mods"
+            cp -r "${dest_dir}/mods"/. "${mods_base_dir}/PalSchema/mods"/
+            chown -R steam:steam "${mods_base_dir}/PalSchema/mods" 2>/dev/null || true
+            for d in "${dest_dir}/mods"/*; do
+                if [[ -d "$d" ]]; then
+                    deployed_palschema_mods+=($(basename "$d"))
+                fi
+            done
+        fi
     fi
 
     # 4d. Handle flat PalSchema mods (contains blueprints, raw, translations, or items folder at root)


### PR DESCRIPTION
Three separate bugs found while testing `AUTO_UPDATE_ENABLED`'s live update check and native mod deployment, plus one added feature.

1. **`native_*` tracking keys wrongly treated as removed Workshop IDs** — the "was this ID removed from configuration" check compares every key in the saved state against configured Workshop IDs and treats anything not found as removed. Internal tracking keys like `native_ue4ss-experimental` are never Workshop IDs, so this always fails and forces a restart every single time the server is already running, regardless of whether anything actually changed.

2. **Unquoted iteration was word-splitting mod names with spaces** — even with the fix above, the same loop iterates with `for old_id in $old_ids` (unquoted), so bash splits each line on internal whitespace too, not just between keys. A mod named `LessRestrictiveBuilding Paks` gets torn into `native_LessRestrictiveBuilding` and `Paks` — the first half matches the `native_*` guard, but `Paks` alone doesn't, so it still falls through and triggers a restart.

3. **PalSchema deployment was copying its own mods directory onto itself** — separately, PalSchema's own deployment hits a `cp: are the same file` error on every single run and aborts the whole script (`set -euo pipefail` is active), meaning nothing after PalSchema in the native mod scan ever gets processed, and the state file's version tracking never gets written correctly for *any* native mod. Traced it to a branch meant to consolidate a mod's own bundled `mods/` subfolder into PalSchema's registry — when it runs for PalSchema itself, source and destination are literally the same path.

4. **Added: real version-comparison for native mods** — previously nothing detected when a native mod's content actually changed while the server was already running, so a new or updated mod dropped into `NativeMods/` was silently ignored until some unrelated restart happened. Added a comparison loop (mirroring the existing Workshop-ID version check) that measures against the mod's own staging directory rather than its deployed copy, since the deployed copy gets recreated on every redeploy regardless of whether the content actually changed.

**Testing:** all confirmed via direct testing against a running server:
- Reproduced each bug live before fixing it
- After all fixes: stable across multiple consecutive "nothing changed" checks, zero false triggers
- A real mod content change is correctly detected and triggers a proper graceful restart
- All native mods, including ones with spaces in their names, now get correctly tracked in the state file for the first time

---
*This fix was written with the assistance of Claude Code. All testing described above was verified by me directly against a live server.*