### PR TITLE
fix: AUTO_PAUSE wake monitor silently treated a failed tcpdump as a detected connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [Back to main](README.md#changelog)
 
+## 2026-08-12
+
+- Fixed `AUTO_PAUSE`'s wake-on-connect monitor treating a failed `tcpdump` (e.g. missing `NET_ADMIN`) as a detected connection - by @THATDONFC
+  - Without this fix, enabling `AUTO_PAUSE_ENABLED=true` without also granting `NET_ADMIN` caused the server to wake itself up almost immediately on every pause cycle, silently defeating the resource savings the feature is meant to provide.
+  - The monitor now checks `tcpdump`'s actual exit status; only a genuine captured packet triggers a wake. A failed monitor now correctly falls back to REST-API-only wake, matching the documented degraded behavior.
+
 ## 2026-08-08
 
 - Added `AUTO_PAUSE_ENABLED` to freeze the gameserver when empty and save resources - by @THATDONFC

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
     AUTO_PAUSE_TIMEOUT=180 \
     AUTO_PAUSE_LOG=false \
     AUTO_PAUSE_KNOCKD_IF= \
+    AUTO_PAUSE_HEARTBEAT_PULSE=false \
+    AUTO_PAUSE_HEARTBEAT_INTERVAL=90 \
+    AUTO_PAUSE_HEARTBEAT_DURATION=4 \
     # Custom-script-settings
     CUSTOM_SCRIPT_ENABLED=false \
     CUSTOM_SCRIPT_PATH="/palworld/custom-script.sh" \

--- a/includes/autopause-monitor.sh
+++ b/includes/autopause-monitor.sh
@@ -53,7 +53,7 @@ function autopause_monitor_start() {
             fi
             autopause_request_resume "incoming connection detected"
         else
-            ew "$(autopause_ts) > AUTO_PAUSE monitor: tcpdump failed (missing NET_ADMIN?), this cycle will only wake on REST API activity"
+            ew "$(autopause_ts) > AUTO_PAUSE monitor: tcpdump failed - likely missing the NET_ADMIN capability (uncomment cap_add in compose.yml), this cycle will only wake on REST API activity"
         fi
     ) &
     echo "$!" > "${AUTOPAUSE_MONITOR_PIDFILE}" 2>/dev/null || true

--- a/includes/autopause-monitor.sh
+++ b/includes/autopause-monitor.sh
@@ -47,11 +47,14 @@ function autopause_monitor_start() {
     done
 
     (
-        tcpdump -i "nflog:${AUTOPAUSE_NFLOG_GROUP}" -n -c 1 >/dev/null 2>&1
-        if [[ -n $AUTO_PAUSE_LOG ]] && [[ "${AUTO_PAUSE_LOG,,}" == "true" ]]; then
-            ei "$(autopause_ts) > AUTO_PAUSE monitor: incoming connection detected"
+        if tcpdump -i "nflog:${AUTOPAUSE_NFLOG_GROUP}" -n -c 1 >/dev/null 2>&1; then
+            if [[ -n $AUTO_PAUSE_LOG ]] && [[ "${AUTO_PAUSE_LOG,,}" == "true" ]]; then
+                ei "$(autopause_ts) > AUTO_PAUSE monitor: incoming connection detected"
+            fi
+            autopause_request_resume "incoming connection detected"
+        else
+            ew "$(autopause_ts) > AUTO_PAUSE monitor: tcpdump failed (missing NET_ADMIN?), this cycle will only wake on REST API activity"
         fi
-        autopause_request_resume "incoming connection detected"
     ) &
     echo "$!" > "${AUTOPAUSE_MONITOR_PIDFILE}" 2>/dev/null || true
 


### PR DESCRIPTION
The wake-on-connect subshell in `autopause-monitor.sh` never checked `tcpdump`'s exit status - it unconditionally logged "incoming connection detected" and requested a resume regardless of whether `tcpdump` actually captured a packet.

Caused by: without the `NET_ADMIN` capability (commented out by default in `compose.yml`), `tcpdump` fails instantly with `operation not permitted`. Since nothing checked that, every pause cycle self-cancelled almost immediately, silently defeating AUTO_PAUSE's resource savings for anyone who enables it without separately granting `NET_ADMIN`.

Fix: check `tcpdump`'s actual exit status, only a real `exit 0` triggers a wake. A failure now logs a clear warning pointing at the fix and correctly falls back to REST-API-only wake, matching the documented degraded behavior.

Also added the `AUTO_PAUSE_HEARTBEAT_*` env vars to the `Dockerfile`'s `ENV` block - they were already in `default.env`/docs from the merged micro-unpause PR but missing there.

### Testing

- Confirmed the root cause directly: `tcpdump -i nflog:100 -n -c 1` without `NET_ADMIN` → `operation not permitted`, exit 255.
- A/B reproduced on a live server: without `NET_ADMIN`, false wake every cycle, same-second. With it, genuinely stayed paused for 5+ minutes.
- Ruled out real external traffic as the cause via packet capture on both sides of the NAT - zero packets either way.
- Post-fix: without `NET_ADMIN`, correctly stays paused. With it, a real UDP packet still correctly triggers a wake - confirms the fix doesn't break genuine wake-on-connect.
