### PR TITLE
fix: give the game's pty a real window size so console lines don't wrap mid-word

### DIFF
--- a/includes/server.sh
+++ b/includes/server.sh
@@ -98,7 +98,28 @@ function start_server() {
     # Real pty (via script) so Wine's WriteConsoleW transcodes instead of emitting raw UTF-16LE
     local wine_cmd
     wine_cmd="exec $(printf '%q ' "${WINE_BIN}" "${GAME_BIN}" "${START_OPTIONS[@]}")"
-    script -qec "${wine_cmd}" /dev/null
+
+    script -qec "${wine_cmd}" /dev/null &
+    local script_pid="$!"
+
+    # script's own stdin is /dev/null (not a real tty), so its pty defaults to
+    # a 0x0 window - Wine's console emulation then wraps long lines at some
+    # narrow fallback width, splitting them mid-word. Give it a wide window
+    # before Wine gets a chance to query it.
+    local fd target pty_dev=""
+    for _ in {1..30}; do
+        for fd in "/proc/${script_pid}/fd/"*; do
+            target=$(readlink "${fd}" 2>/dev/null) || true
+            if [[ "${target}" =~ ^/dev/pts/[0-9]+$ ]]; then
+                pty_dev="${target}"
+                break 2
+            fi
+        done
+        sleep 0.1
+    done
+    [[ -n "${pty_dev}" ]] && stty -F "${pty_dev}" cols 500 rows 500 2>/dev/null || true
+
+    wait "${script_pid}"
 }
 
 function stop_server() {


### PR DESCRIPTION
## What this fixes

Long console lines sometimes get split mid-word in `docker logs`/Portainer. For example, PalDefender's `[PalImportRules] Loaded Pal import rules. Default='loaded', PerPalOverrides=0.` shows up split as "...Per" on one line and "PalOverrides=0." on the next, even though the same line is correct and unbroken in PalDefender's own log file.

The cause is `script`'s pty. Its stdin is `/dev/null`, not a real tty, so the pty it allocates internally defaults to a 0x0 window size. Wine's console emulation queries this once during its own startup and falls back to some narrow default width, then wraps long lines at that width, inserting a real newline mid-word.

## Fix

`start_server()` now launches `script` in the background instead of the foreground. It waits for `script`'s pty to appear by scanning `/proc/<pid>/fd` for the `/dev/pts/N` symlink, then sets a wide window (`stty cols 500 rows 500`) on it before Wine has a chance to query it. It then waits for `script` to exit, same as before. This doesn't need any new capabilities since it only reads `script`'s own fds, a direct parent-child relationship.

## How it was tested

Reproduced by triggering a real PalDefender action (`ReloadConfig`) that reliably logs the long line above. Confirmed the line was corrupted on every attempt before this fix. Also tried a live `stty` on the already-running pty after the fact, which didn't fix it, confirming Wine caches the width early rather than checking it on every write. After the fix, the pty reports the new window size automatically, and the same line prints correctly across the startup burst, two independently triggered reloads, and a reload after a pause/resume cycle. Zero mid-word splits across the whole test.
